### PR TITLE
Add optional iconBuilder property

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -292,7 +292,11 @@ class CustomNavBarWidget extends StatelessWidget {
                     color: isSelected
                         ? (item.activeColorSecondary ?? item.activeColorPrimary)
                         : item.inactiveColorPrimary ?? item.activeColorPrimary),
-                child: isSelected ? item.icon : item.inactiveIcon ?? item.icon,
+                child: item.iconBuilder != null
+                    ? item.iconBuilder!(isSelected, item.icon)
+                    : isSelected
+                        ? item.icon
+                        : item.inactiveIcon ?? item.icon,
               ),
             ),
             Padding(

--- a/lib/models/persistent_bottom_nav_item.widget.dart
+++ b/lib/models/persistent_bottom_nav_item.widget.dart
@@ -5,6 +5,7 @@ class PersistentBottomNavBarItem {
   PersistentBottomNavBarItem(
       {required this.icon,
       this.inactiveIcon,
+      this.iconBuilder,
       this.title,
       this.contentPadding = 5.0,
       this.activeColorPrimary = CupertinoColors.activeBlue,
@@ -26,6 +27,9 @@ class PersistentBottomNavBarItem {
 
   ///In-Active icon for the bar item.
   final Widget? inactiveIcon;
+
+  ///Icon builder, for advanced customizations.
+  final Widget Function(bool isSelected, Widget icon)? iconBuilder;
 
   ///Title for the bar item. Might not appear is some `styles`.
   final String? title;

--- a/lib/nav_bar_styles/neumorphic_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/neumorphic_bottom_nav_bar.widget.dart
@@ -24,8 +24,11 @@ class NeumorphicBottomNavBar extends StatelessWidget {
                                 item.activeColorPrimary)
                             : item.inactiveColorPrimary ??
                                 item.activeColorPrimary),
-                    child:
-                        isSelected ? item.icon : item.inactiveIcon ?? item.icon,
+                    child: item.iconBuilder != null
+                        ? item.iconBuilder!(isSelected, item.icon)
+                        : isSelected
+                            ? item.icon
+                            : item.inactiveIcon ?? item.icon,
                   ),
                 ),
                 Padding(
@@ -60,7 +63,11 @@ class NeumorphicBottomNavBar extends StatelessWidget {
                   color: isSelected
                       ? (item.activeColorSecondary ?? item.activeColorPrimary)
                       : item.inactiveColorPrimary ?? item.activeColorPrimary),
-              child: isSelected ? item.icon : item.inactiveIcon ?? item.icon,
+              child: item.iconBuilder != null
+                  ? item.iconBuilder!(isSelected, item.icon)
+                  : isSelected
+                      ? item.icon
+                      : item.inactiveIcon ?? item.icon,
             );
 
   Widget _buildItem(

--- a/lib/nav_bar_styles/simple_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/simple_bottom_nav_bar.widget.dart
@@ -36,9 +36,11 @@ class BottomNavSimple extends StatelessWidget {
                                         item.activeColorPrimary)
                                     : item.inactiveColorPrimary ??
                                         item.activeColorPrimary),
-                            child: isSelected
-                                ? item.icon
-                                : item.inactiveIcon ?? item.icon,
+                            child: item.iconBuilder != null
+                                ? item.iconBuilder!(isSelected, item.icon)
+                                : isSelected
+                                    ? item.icon
+                                    : item.inactiveIcon ?? item.icon,
                           ),
                         ),
                         if (item.title == null)

--- a/lib/nav_bar_styles/style_10_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_10_bottom_nav_bar.widget.dart
@@ -48,9 +48,11 @@ class BottomNavStyle10 extends StatelessWidget {
                                     item.activeColorPrimary)
                                 : item.inactiveColorPrimary ??
                                     item.activeColorPrimary),
-                        child: isSelected
-                            ? item.icon
-                            : item.inactiveIcon ?? item.icon,
+                        child: item.iconBuilder != null
+                            ? item.iconBuilder!(isSelected, item.icon)
+                            : isSelected
+                                ? item.icon
+                                : item.inactiveIcon ?? item.icon,
                       ),
                     ),
                     if (item.title == null)

--- a/lib/nav_bar_styles/style_11_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_11_bottom_nav_bar.widget.dart
@@ -71,9 +71,11 @@ class _BottomNavStyle11State extends State<BottomNavStyle11>
                                       item.activeColorPrimary)
                                   : item.inactiveColorPrimary ??
                                       item.activeColorPrimary),
-                          child: isSelected
-                              ? item.icon
-                              : item.inactiveIcon ?? item.icon,
+                          child: item.iconBuilder != null
+                              ? item.iconBuilder!(isSelected, item.icon)
+                              : isSelected
+                                  ? item.icon
+                                  : item.inactiveIcon ?? item.icon,
                         ),
                       ),
                       if (item.title == null)

--- a/lib/nav_bar_styles/style_12_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_12_bottom_nav_bar.widget.dart
@@ -71,9 +71,11 @@ class _BottomNavStyle12State extends State<BottomNavStyle12>
                                       item.activeColorPrimary)
                                   : item.inactiveColorPrimary ??
                                       item.activeColorPrimary),
-                          child: isSelected
-                              ? item.icon
-                              : item.inactiveIcon ?? item.icon,
+                          child: item.iconBuilder != null
+                              ? item.iconBuilder!(isSelected, item.icon)
+                              : isSelected
+                                  ? item.icon
+                                  : item.inactiveIcon ?? item.icon,
                         ),
                       ),
                       if (item.title == null)

--- a/lib/nav_bar_styles/style_13_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_13_bottom_nav_bar.widget.dart
@@ -77,9 +77,11 @@ class _BottomNavStyle13State extends State<BottomNavStyle13>
                                     item.activeColorPrimary)
                                 : item.inactiveColorPrimary ??
                                     item.activeColorPrimary),
-                        child: isSelected
-                            ? item.icon
-                            : item.inactiveIcon ?? item.icon,
+                        child: item.iconBuilder != null
+                            ? item.iconBuilder!(isSelected, item.icon)
+                            : isSelected
+                                ? item.icon
+                                : item.inactiveIcon ?? item.icon,
                       ),
                     ),
                     if (item.title == null)

--- a/lib/nav_bar_styles/style_14_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_14_bottom_nav_bar.widget.dart
@@ -77,9 +77,11 @@ class _BottomNavStyle14State extends State<BottomNavStyle14>
                                     item.activeColorPrimary)
                                 : item.inactiveColorPrimary ??
                                     item.activeColorPrimary),
-                        child: isSelected
-                            ? item.icon
-                            : item.inactiveIcon ?? item.icon,
+                        child: item.iconBuilder != null
+                            ? item.iconBuilder!(isSelected, item.icon)
+                            : isSelected
+                                ? item.icon
+                                : item.inactiveIcon ?? item.icon,
                       ),
                     ),
                     if (item.title == null)

--- a/lib/nav_bar_styles/style_15_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_15_bottom_nav_bar.widget.dart
@@ -45,9 +45,11 @@ class BottomNavStyle15 extends StatelessWidget {
                                         item.activeColorPrimary)
                                     : item.inactiveColorPrimary ??
                                         item.activeColorPrimary),
-                            child: isSelected
-                                ? item.icon
-                                : item.inactiveIcon ?? item.icon,
+                            child: item.iconBuilder != null
+                                ? item.iconBuilder!(isSelected, item.icon)
+                                : isSelected
+                                    ? item.icon
+                                    : item.inactiveIcon ?? item.icon,
                           ),
                         ),
                         if (item.title == null)
@@ -124,9 +126,12 @@ class BottomNavStyle15 extends StatelessWidget {
                                           size: item.iconSize,
                                           color: item.activeColorSecondary ??
                                               item.activeColorPrimary),
-                                      child: isSelected
-                                          ? item.icon
-                                          : item.inactiveIcon ?? item.icon,
+                                      child: item.iconBuilder != null
+                                          ? item.iconBuilder!(
+                                              isSelected, item.icon)
+                                          : isSelected
+                                              ? item.icon
+                                              : item.inactiveIcon ?? item.icon,
                                     ),
                                   ),
                                 ],

--- a/lib/nav_bar_styles/style_16_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_16_bottom_nav_bar.widget.dart
@@ -41,9 +41,11 @@ class BottomNavStyle16 extends StatelessWidget {
                                         item.activeColorPrimary)
                                     : item.inactiveColorPrimary ??
                                         item.activeColorPrimary),
-                            child: isSelected
-                                ? item.icon
-                                : item.inactiveIcon ?? item.icon,
+                            child: item.iconBuilder != null
+                                ? item.iconBuilder!(isSelected, item.icon)
+                                : isSelected
+                                    ? item.icon
+                                    : item.inactiveIcon ?? item.icon,
                           ),
                         ),
                         if (item.title == null)
@@ -125,9 +127,12 @@ class BottomNavStyle16 extends StatelessWidget {
                                         color: item.activeColorSecondary ??
                                             item.activeColorPrimary,
                                       ),
-                                      child: isSelected
-                                          ? item.icon
-                                          : item.inactiveIcon ?? item.icon,
+                                      child: item.iconBuilder != null
+                                          ? item.iconBuilder!(
+                                              isSelected, item.icon)
+                                          : isSelected
+                                              ? item.icon
+                                              : item.inactiveIcon ?? item.icon,
                                     ),
                                   ),
                                 ],

--- a/lib/nav_bar_styles/style_17_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_17_bottom_nav_bar.widget.dart
@@ -41,9 +41,11 @@ class BottomNavStyle17 extends StatelessWidget {
                                         item.activeColorPrimary)
                                     : item.inactiveColorPrimary ??
                                         item.activeColorPrimary),
-                            child: isSelected
-                                ? item.icon
-                                : item.inactiveIcon ?? item.icon,
+                            child: item.iconBuilder != null
+                                ? item.iconBuilder!(isSelected, item.icon)
+                                : isSelected
+                                    ? item.icon
+                                    : item.inactiveIcon ?? item.icon,
                           ),
                         ),
                         if (item.title == null)
@@ -116,9 +118,11 @@ class BottomNavStyle17 extends StatelessWidget {
                                         item.activeColorPrimary)
                                     : item.inactiveColorPrimary ??
                                         item.activeColorPrimary),
-                            child: isSelected
-                                ? item.icon
-                                : item.inactiveIcon ?? item.icon,
+                            child: item.iconBuilder != null
+                                ? item.iconBuilder!(isSelected, item.icon)
+                                : isSelected
+                                    ? item.icon
+                                    : item.inactiveIcon ?? item.icon,
                           ),
                         ),
                       ],

--- a/lib/nav_bar_styles/style_18_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_18_bottom_nav_bar.widget.dart
@@ -41,9 +41,11 @@ class BottomNavStyle18 extends StatelessWidget {
                                         item.activeColorPrimary)
                                     : item.inactiveColorPrimary ??
                                         item.activeColorPrimary),
-                            child: isSelected
-                                ? item.icon
-                                : item.inactiveIcon ?? item.icon,
+                            child: item.iconBuilder != null
+                                ? item.iconBuilder!(isSelected, item.icon)
+                                : isSelected
+                                    ? item.icon
+                                    : item.inactiveIcon ?? item.icon,
                           ),
                         ),
                         if (item.title == null)
@@ -120,9 +122,11 @@ class BottomNavStyle18 extends StatelessWidget {
                                         item.activeColorPrimary)
                                     : item.inactiveColorPrimary ??
                                         item.activeColorPrimary),
-                            child: isSelected
-                                ? item.icon
-                                : item.inactiveIcon ?? item.icon,
+                            child: item.iconBuilder != null
+                                ? item.iconBuilder!(isSelected, item.icon)
+                                : isSelected
+                                    ? item.icon
+                                    : item.inactiveIcon ?? item.icon,
                           ),
                         ),
                       ],

--- a/lib/nav_bar_styles/style_19_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_19_bottom_nav_bar.widget.dart
@@ -23,8 +23,11 @@ class BottomNavStyle19 extends StatelessWidget {
                               item.activeColorPrimary)
                           : item.inactiveColorPrimary ??
                               item.activeColorPrimary),
-                  child:
-                      isSelected ? item.icon : item.inactiveIcon ?? item.icon,
+                  child: item.iconBuilder != null
+                      ? item.iconBuilder!(isSelected, item.icon)
+                      : isSelected
+                          ? item.icon
+                          : item.inactiveIcon ?? item.icon,
                 ),
               ),
             );

--- a/lib/nav_bar_styles/style_1_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_1_bottom_nav_bar.widget.dart
@@ -43,9 +43,11 @@ class BottomNavStyle1 extends StatelessWidget {
                                       item.activeColorPrimary)
                                   : item.inactiveColorPrimary ??
                                       item.activeColorPrimary),
-                          child: isSelected
-                              ? item.icon
-                              : item.inactiveIcon ?? item.icon,
+                          child: item.iconBuilder != null
+                              ? item.iconBuilder!(isSelected, item.icon)
+                              : isSelected
+                                  ? item.icon
+                                  : item.inactiveIcon ?? item.icon,
                         ),
                       ),
                     ),

--- a/lib/nav_bar_styles/style_2_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_2_bottom_nav_bar.widget.dart
@@ -29,9 +29,11 @@ class BottomNavStyle2 extends StatelessWidget {
                                     item.activeColorPrimary)
                                 : item.inactiveColorPrimary ??
                                     item.activeColorPrimary),
-                        child: isSelected
-                            ? item.icon
-                            : item.inactiveIcon ?? item.icon,
+                        child: item.iconBuilder != null
+                            ? item.iconBuilder!(isSelected, item.icon)
+                            : isSelected
+                                ? item.icon
+                                : item.inactiveIcon ?? item.icon,
                       ),
                     ),
                     if (item.title == null)

--- a/lib/nav_bar_styles/style_3_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_3_bottom_nav_bar.widget.dart
@@ -38,9 +38,11 @@ class BottomNavStyle3 extends StatelessWidget {
                                     item.activeColorPrimary)
                                 : item.inactiveColorPrimary ??
                                     item.activeColorPrimary),
-                        child: isSelected
-                            ? item.icon
-                            : item.inactiveIcon ?? item.icon,
+                        child: item.iconBuilder != null
+                            ? item.iconBuilder!(isSelected, item.icon)
+                            : isSelected
+                                ? item.icon
+                                : item.inactiveIcon ?? item.icon,
                       ),
                     ),
                     if (item.title == null)

--- a/lib/nav_bar_styles/style_4_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_4_bottom_nav_bar.widget.dart
@@ -37,9 +37,11 @@ class BottomNavStyle4 extends StatelessWidget {
                                     item.activeColorPrimary)
                                 : item.inactiveColorPrimary ??
                                     item.activeColorPrimary),
-                        child: isSelected
-                            ? item.icon
-                            : item.inactiveIcon ?? item.icon,
+                        child: item.iconBuilder != null
+                            ? item.iconBuilder!(isSelected, item.icon)
+                            : isSelected
+                                ? item.icon
+                                : item.inactiveIcon ?? item.icon,
                       ),
                     ),
                     if (item.title == null)

--- a/lib/nav_bar_styles/style_5_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_5_bottom_nav_bar.widget.dart
@@ -29,9 +29,11 @@ class BottomNavStyle5 extends StatelessWidget {
                                     item.activeColorPrimary)
                                 : item.inactiveColorPrimary ??
                                     item.activeColorPrimary),
-                        child: isSelected
-                            ? item.icon
-                            : item.inactiveIcon ?? item.icon,
+                        child: item.iconBuilder != null
+                            ? item.iconBuilder!(isSelected, item.icon)
+                            : isSelected
+                                ? item.icon
+                                : item.inactiveIcon ?? item.icon,
                       ),
                     ),
                     Container(

--- a/lib/nav_bar_styles/style_6_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_6_bottom_nav_bar.widget.dart
@@ -71,9 +71,11 @@ class _BottomNavStyle6State extends State<BottomNavStyle6>
                                         item.activeColorPrimary)
                                     : item.inactiveColorPrimary ??
                                         item.activeColorPrimary),
-                            child: isSelected
-                                ? item.icon
-                                : item.inactiveIcon ?? item.icon,
+                            child: item.iconBuilder != null
+                                ? item.iconBuilder!(isSelected, item.icon)
+                                : isSelected
+                                    ? item.icon
+                                    : item.inactiveIcon ?? item.icon,
                           ),
                         ),
                         if (item.title == null)

--- a/lib/nav_bar_styles/style_7_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_7_bottom_nav_bar.widget.dart
@@ -50,9 +50,11 @@ class BottomNavStyle7 extends StatelessWidget {
                                     item.activeColorPrimary)
                                 : item.inactiveColorPrimary ??
                                     item.activeColorPrimary),
-                        child: isSelected
-                            ? item.icon
-                            : item.inactiveIcon ?? item.icon,
+                        child: item.iconBuilder != null
+                            ? item.iconBuilder!(isSelected, item.icon)
+                            : isSelected
+                                ? item.icon
+                                : item.inactiveIcon ?? item.icon,
                       ),
                     ),
                     if (item.title == null)

--- a/lib/nav_bar_styles/style_8_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_8_bottom_nav_bar.widget.dart
@@ -65,9 +65,11 @@ class _BottomNavStyle8State extends State<BottomNavStyle8>
                                   item.activeColorPrimary)
                               : item.inactiveColorPrimary ??
                                   item.activeColorPrimary),
-                      child: isSelected
-                          ? item.icon
-                          : item.inactiveIcon ?? item.icon,
+                      child: item.iconBuilder != null
+                          ? item.iconBuilder!(isSelected, item.icon)
+                          : isSelected
+                              ? item.icon
+                              : item.inactiveIcon ?? item.icon,
                     ),
                   ),
                   if (item.title == null)

--- a/lib/nav_bar_styles/style_9_bottom_nav_bar.widget.dart
+++ b/lib/nav_bar_styles/style_9_bottom_nav_bar.widget.dart
@@ -41,9 +41,11 @@ class BottomNavStyle9 extends StatelessWidget {
                                     item.activeColorPrimary)
                                 : item.inactiveColorPrimary ??
                                     item.activeColorPrimary),
-                        child: isSelected
-                            ? item.icon
-                            : item.inactiveIcon ?? item.icon,
+                        child: item.iconBuilder != null
+                            ? item.iconBuilder!(isSelected, item.icon)
+                            : isSelected
+                                ? item.icon
+                                : item.inactiveIcon ?? item.icon,
                       ),
                     ),
                     if (item.title == null)


### PR DESCRIPTION
Add an optional `iconBuilder` property on the `PersistentBottomNavBarItem` element. This allows to add even more customization on the navbar items.

---

This example below add a rounded background on the selected tab, with a cross-fade animation when the tab is selected:

![Apr-16-2021 17-57-11](https://user-images.githubusercontent.com/1045997/115051544-39d2a800-9edd-11eb-876e-81c72c1a9061.gif)


```dart
PersistentBottomNavBarItem(
  icon: CupertinoIcons.settings,
  iconBuilder: iconBuilder,
  activeColorPrimary: Colors.blue,
  inactiveColorPrimary: CupertinoColors.systemGrey,
);
```

```dart
var iconBuilder = (isSelected, icon) {
  return AnimatedContainer(
    decoration: new BoxDecoration(
      borderRadius: new BorderRadius.all(const Radius.circular(20)),
      color: isSelected ? selectedBackground : Colors.transparent,
    ),
    width: 40,
    height: 40,
    duration: const Duration(milliseconds: 150),
    curve: Curves.ease,
    child: icon,
  );
};
```

